### PR TITLE
Explicitly cast len as an integer

### DIFF
--- a/callhorizons/callhorizons.py
+++ b/callhorizons/callhorizons.py
@@ -130,7 +130,8 @@ class query():
     def __len__(self):
         """returns total number of epochs that have been queried"""
         try:
-            return self.data.shape[0]
+            # Cast to int because a long is returned from shape on Windows.
+            return int(self.data.shape[0])
         except AttributeError:
             return 0
     


### PR DESCRIPTION
I was working with a student who is using `callhorizons` on Windows. On Windows, numpy shapes are returned as `long`, not `int`. When `return len(self)` is hit in `query.get_elements`, an exception is raised because the len isn't an `int`. This fixes the issue by converting the return value in `__len__` to an `int`.