### PR TITLE
Allow small body names.

### DIFF
--- a/callhorizons/tests/test_callhorizons.py
+++ b/callhorizons/tests/test_callhorizons.py
@@ -109,6 +109,8 @@ def test_pyephem():
 
 def test_designations():
     """Test comet and asteroid name to designation transformations."""
+
+    # name: expected result
     comets = {
         '1P/Halley': '1P',
         '3D/Biela': '3D',
@@ -132,7 +134,7 @@ def test_designations():
         '(2001) Einstein': '2001',
         '2001 AT1': '2001 AT1',
         '(1714) Sy': '1714',
-        '1714 SY': '1714 SY',
+        '1714 SY': '1714 SY',  # not real; note pot. confusion with prev. item
         '2014 MU69': '2014 MU69',
         '2017 AA': '2017 AA',
     }
@@ -146,10 +148,35 @@ def test_designations():
         q = callhorizons.query(asteroid, smallbody=True)
         _des = q.parse_asteroid()
         assert _des == des, 'Parsed {}: {} != {}'.format(asteroid, _des, des)
-        
+
+def test_comet():
+    """Test CAP and orbit record numbers for a comet."""
+    
+    # test failure when multiple orbital solutions are available
+    target = callhorizons.query('9P', cap=False)
+    target.set_discreteepochs([2451544.500000])
+
+    try:
+        target.get_ephemerides('G37')
+    except ValueError as e:
+        assert 'Ambiguous target name' in str(e)
+    else:
+        raise
+
+    # switch to current ephemeris, this should be successful
+    target.cap = True
+    target.get_ephemerides('G37')
+    assert len(target) == 1
+
+    # Test orbit record number, note that NAIF may change these at any time.
+    target = callhorizons.query('900191')
+    target.set_discreteepochs([2451544.500000])
+    target.get_ephemerides('G37')
+    assert len(target) == 1
     
 if __name__ == "__main__":
     test_ephemerides()
     test_elements()
     test_pyephem()
     test_designations()
+    test_comet()

--- a/callhorizons/tests/test_callhorizons.py
+++ b/callhorizons/tests/test_callhorizons.py
@@ -105,10 +105,51 @@ def test_pyephem():
     assert ((target['RA'][0]-ephem_ra)*3600) < 0.1
     assert ((target['DEC'][0]-ephem_dec)*3600) < 0.1
     assert (target['V'][0]-ephem_mag) < 0.1
-    
+
+
+def test_designations():
+    """Test comet and asteroid name to designation transformations."""
+    comets = {
+        '1P/Halley': '1P',
+        '3D/Biela': '3D',
+        '9P/Tempel 1': '9P',
+        '73P/Schwassmann Wachmann 3 C': '73P',  # Note the missing "C"!
+        '73P-C/Schwassmann Wachmann 3 C': '73P-C',
+        '73P-BB': '73P-BB',
+        '322P': '322P',
+        'X/1106 C1': 'X/1106 C1',
+        'P/1994 N2 (McNaught-Hartley)': 'P/1994 N2',
+        'P/2001 YX127 (LINEAR)': 'P/2001 YX127',
+        'C/-146 P1': 'C/-146 P1' ,
+        'C/2001 A2-A (LINEAR)': 'C/2001 A2-A',
+        'C/2013 US10': 'C/2013 US10',
+        'C/2015 V2 (Johnson)': 'C/2015 V2',
+    }
+
+    asteroids = {
+        '1': '1',
+        '(2) Pallas': '2',
+        '(2001) Einstein': '2001',
+        '2001 AT1': '2001 AT1',
+        '(1714) Sy': '1714',
+        '1714 SY': '1714 SY',
+        '2014 MU69': '2014 MU69',
+        '2017 AA': '2017 AA',
+    }
+
+    for comet, des in comets.items():
+        q = callhorizons.query(comet, smallbody=True)
+        _des = q.parse_comet() 
+        assert _des == des, 'Parsed {}: {} != {}'.format(comet, _des, des)
+
+    for asteroid, des in asteroids.items():
+        q = callhorizons.query(asteroid, smallbody=True)
+        _des = q.parse_asteroid()
+        assert _des == des, 'Parsed {}: {} != {}'.format(asteroid, _des, des)
+        
     
 if __name__ == "__main__":
     test_ephemerides()
     test_elements()
     test_pyephem()
-
+    test_designations()

--- a/doc/use.rst
+++ b/doc/use.rst
@@ -14,6 +14,10 @@ How to Use It?
 
      dq = callhorizons.query('3552')
 
+   name and number::
+
+     dq = callhorizons.query('(3552) Don Quixote')
+     
    designation::
 
      dq = callhorizons.query('1983 SA')
@@ -21,6 +25,52 @@ How to Use It?
    or packed designation::
 
      dq = callhorizons.query('J83S00A')
+
+   **Comet** names may be the full periodic number and name::
+
+     dq = callhorizons.query('1P/Halley')
+     dq = callhorizons.query('3D/Biela')
+
+   periodic number only::
+
+     dq = callhorizons.query('9P')
+
+   orbit solution ID::
+
+     dq = callhorizons.query('900190')
+     
+   temporary designation::
+
+     dq = callhorizons.query('P/2001 YX127')
+
+   temporary designation with name::
+
+     dq = callhorizons.query('P/1994 N2 (McNaught-Hartley)')
+
+   or long period / hyperbolic comet designation, with or without name::
+
+     dq = callhorizons.query('C/2013 US10 (Catalina)')     
+     dq = callhorizons.query('C/2012 S1')
+
+   Fragments may also be requested::
+  
+     dq = callhorizons.query('C/2001 A2-A')
+     dq = callhorizons.query('73P-C/Schwassmann Wachmann 3 C')
+
+   but note that the name is ignored.  The following will not return
+   fragment B, but instead the ephemeris for 73P (compare with the
+   previous example)::
+
+     dq = callhorizons.query('73P/Schwassmann Wachmann 3 B')
+
+   By default, comet queries will return the most recent or current
+   apparition (HORIZONS's 'CAP' parameter).  This behavior can be
+   disabled with the `cap=False` keyword argument::
+
+     dq = callhorizons.query('9P', cap=False)
+
+   If there are multiple orbit solutions available, CALLHORIZONS will
+   raise a ``ValueError`` and provide the URL with explanations.
 
    You can also query **major bodies** (planets and moons) and
    **spacecraft**. This is a little bit trickier, since there are no


### PR DESCRIPTION
Added tests and branching for comets and asteroid designations, which may contain names.  The `targetname` is parsed and transformed into a designation that HORIZONS should understand.  This includes a test for comet orbit record IDs.  If any of the three tests fails (record ID, comet, asteroid), then it falls back on the old code.  The documentation has been edited to reflect these changes.

The tests and parsing was designed with the following cases in mind.  Note that '1 Ceres' will parse as '1 C' and the HORIZONS call will fail.  I am not sure how to handle this case.  I have written the code with the [IAU format](https://www.iau.org/public/themes/naming/#minorplanets) in mind: '(1) Ceres'.  Are there other cases that I am missing?

|Comet                         | Designation | Note
|---|---|---|
|1P/Halley                     | 1P	     |
|3D/Biela                      | 3D	     |
|9P/Tempel 1                   | 9P	     |
|73P/Schwassmann Wachmann 3 C  | 73P         | Note the missing "C"!
|73P-C/Schwassmann Wachmann 3 C| 73P-C	     |
|73P-BB                        | 73P-BB	     |
|322P                          | 322P	     |
|X/1106 C1                     | X/1106 C1   |
|P/1994 N2 (McNaught-Hartley)  | P/1994 N2   |
|P/2001 YX127 (LINEAR)         | P/2001 YX127|
|C/-146 P1                     | C/-146 P1   |
|C/2001 A2-A (LINEAR)          | C/2001 A2-A |
|C/2013 US10                   | C/2013 US10 |
|C/2015 V2 (Johnson)           | C/2015 V2   |

|Asteroid       | Designation| Note
|---|---|---|
|1              | 1	     |
|(2) Pallas     | 2	     |
|(2001) Einstein| 2001	     |
|2001 AT1       | 2001 AT1   |
|(1714) Sy      | 1714	     |
|1714 SY        | 1714 SY    | Although not a real name, note the near-confusion with (1714)
|2014 MU69      | 2014 MU69  |
|2017 AA        | 2017 AA    |