### PR TITLE
Remove warning about truncation limit 

### DIFF
--- a/callhorizons/callhorizons.py
+++ b/callhorizons/callhorizons.py
@@ -479,9 +479,6 @@ class query():
                    urllib.quote(self.targetname.encode("utf8")) + "%3B'"
 
         if self.discreteepochs is not None:
-            if len(self.discreteepochs) > 15:
-                print ('CALLHORIZONS WARNING: more than 15 discrete epochs',
-                       'provided; output may be truncated.')
             url += "&TLIST="
             for date in self.discreteepochs:
                 url += "'" + str(date) + "'"
@@ -951,9 +948,6 @@ class query():
 
 
         if self.discreteepochs is not None:
-            if len(self.discreteepochs) > 15:
-                print ('CALLHORIZONS WARNING: more than 15 discrete epochs ',
-                       'provided; output may be truncated.')
             url += "&TLIST="
             for date in self.discreteepochs:
                 url += "'" + str(date) + "'"


### PR DESCRIPTION
This removes the truncation limit warning in get_ephemerides and get_elements. I've contacted the JPL Horizons team and they confirmed that this was an unintended limitation in the CGI script that truncated the epochs provided in TLIST to around 15. The batch interface is working now without the truncation.