### PR TITLE
Respect comet=True and asteroid=True.

### DIFF
--- a/callhorizons/callhorizons.py
+++ b/callhorizons/callhorizons.py
@@ -49,8 +49,8 @@ class query():
 
     ### constructor
 
-    def __init__(self, targetname, smallbody=True, cap=True, comet=False,
-                 asteroid=False):
+    def __init__(self, targetname, smallbody=True, cap=True, comet=None,
+                 asteroid=None):
         """
         Initialize query to Horizons
 
@@ -71,14 +71,16 @@ class query():
         self.targetname     = str(targetname)
         self.not_smallbody  = not smallbody
         self.cap            = cap
-        self.comet = comet # is this object a comet?
-        self.asteroid = asteroid  # is this object an asteroid?
+        self.comet          = comet # is this object a comet?
+        self.asteroid       = asteroid  # is this object an asteroid?
         self.start_epoch    = None
         self.stop_epoch     = None
         self.step_size      = None
         self.discreteepochs = None
         self.url            = None
         self.data           = None
+
+        assert not (self.comet and self.asteroid), 'Only one of comet or asteroid can be `True`.'
         
         return None
 
@@ -314,16 +316,20 @@ class query():
         """`True` if `targetname` appears to be a comet. """
 
         # treat this object as comet if there is a prefix/number
-        if self.comet:
-            return True
+        if self.comet is not None:
+            return self.comet
+        elif self.asteroid is not None:
+            return not self.asteroid
         else:
             return (self.parse_comet()[0] is not None or
                     self.parse_comet()[1] is not None)
 
     def isasteroid(self):
         """`True` if `targetname` appears to be an asteroid."""
-        if self.asteroid:
-            return True
+        if self.asteroid is not None:
+            return self.asteroid
+        elif self.comet is not None:
+            return not self.comet
         else:
             return any(self.parse_asteroid()) is not None
 


### PR DESCRIPTION
Hi @mommermi ,

I have a partial solution for issue #11 through updates on the `comet` and `asteroid` parameters.  A full solution will need some more work on the comet and asteroid pattern matching.

The problem: `query(obj, comet=True)` is not respected when object names are similar to asteroids, e.g., 'C/2016 KA'.

This PR sets the default `comet` and `asteroid` parameter values to `None`, and ensures that both `comet` and `asteroid` are not simultaneously true.  `iscomet` and `isasteroid` have been edited to enforce the binary nature of objects, e.g., if `comet=True` then `isasteroid()` returns `False`, independent of the object name.  This approach fails if we want to label interstellar objects as a separate type of object.  An alternative approach is to use string matching, e.g., `smallbody='comet'`, `smallbody='asteroid'`, `smallbody='iso'` or similar.
