### PR TITLE
Add support for HORIZONS's NOFRAG flag.

### DIFF
--- a/callhorizons/callhorizons.py
+++ b/callhorizons/callhorizons.py
@@ -49,30 +49,33 @@ class query():
 
     ### constructor
 
-    def __init__(self, targetname, smallbody=True, cap=True, comet=False,
-                 asteroid=False):
-        """
-        Initialize query to Horizons
+    def __init__(self, targetname, smallbody=True, cap=True, nofrag=False,
+                 comet=False, asteroid=False):
+        """Initialize query to Horizons
 
         :param targetname: HORIZONS-readable target number, name, or designation
         :param smallbody:  boolean  use ``smallbody=False`` if targetname is a 
                            planet or spacecraft (optional, default: `True`); 
                            also use `True` if the targetname is exact and 
                            should be queried as is
-        :param cap: boolean set to `True` to return the current apparition for 
+        :param cap: set to `True` to return the current apparition for
                     comet targets
+        :param nofrag: set to `True` to disable HORIZONS's comet
+                       fragment search
         :param comet: set to `True` if this is a comet (will override 
                       automatic targetname parsing)
         :param asteroid: set to `True` if this is an asteroid (will override 
                          automatic targetname parsing)
         :return: None
+
         """
 
         self.targetname     = str(targetname)
         self.not_smallbody  = not smallbody
         self.cap            = cap
-        self.comet = comet # is this object a comet?
-        self.asteroid = asteroid  # is this object an asteroid?
+        self.nofrag         = nofrag
+        self.comet          = comet # is this object a comet?
+        self.asteroid       = asteroid  # is this object an asteroid?
         self.start_epoch    = None
         self.stop_epoch     = None
         self.step_size      = None
@@ -588,7 +591,7 @@ class query():
                    urllib.quote(str(ident).encode("utf8")) + "%3B'"
         elif self.iscomet() and not self.asteroid:
             # for comets, potentially append the current apparition
-            # (CAP) parameter
+            # (CAP) parameter, or the fragmentation flag (NOFRAG)
             for ident in self.parse_comet():
                 if ident is not None:
                     break
@@ -596,6 +599,7 @@ class query():
                 ident = self.targetname
             url += "&COMMAND='DES=" + \
                    urllib.quote(ident.encode("utf8")) + "%3B" + \
+                   ("NOFRAG%3B" if self.nofrag else "") + \
                    ("CAP'" if self.cap else "'")
         # elif (not self.targetname.replace(' ', '').isalpha() and not
         #      self.targetname.isdigit() and not
@@ -1065,7 +1069,7 @@ class query():
                    urllib.quote(str(ident).encode("utf8")) + "%3B'"
         elif self.iscomet() and not self.asteroid:
             # for comets, potentially append the current apparition
-            # (CAP) parameter
+            # (CAP) parameter, or the fragmentation flag (NOFRAG)
             for ident in self.parse_comet():
                 if ident is not None:
                     break
@@ -1073,6 +1077,7 @@ class query():
                 ident = self.targetname
             url += "&COMMAND='DES=" + \
                    urllib.quote(ident.encode("utf8")) + "%3B" + \
+                   ("NOFRAG%3B" if self.nofrag else "") + \
                    ("CAP'" if self.cap else "'")
         # elif (not self.targetname.replace(' ', '').isalpha() and not
         #      self.targetname.isdigit() and not


### PR DESCRIPTION
Searching for targets like 73P matches multiple objects, even when the current apparition flag (CAP) is enabled.  This is because HORIZONS is not sure if you really wanted 73P, or 73P-C, 73P-BT, etc.  The NOFRAG flag is used to disable fragment searches, so I have added support for it via the `query(nofrag=True)` option.  With this flag enabled, searches for 73P, 73P-C, and 73P-BT are unique and succeed.